### PR TITLE
Fix deprecations

### DIFF
--- a/phi-search-mc.el
+++ b/phi-search-mc.el
@@ -29,7 +29,7 @@
 ;; URL: https://github.com/knu/phi-search-mc.el
 ;; Created: 25 Aug 2013
 ;; Version: 2.2.1
-;; Package-Requires: ((phi-search "2.0.0") (multiple-cursors "1.2.1"))
+;; Package-Requires: ((phi-search "2.0.0") (multiple-cursors "1.2.1") (emacs "25.1"))
 ;; Keywords: search, cursors
 
 ;;; Commentary:

--- a/phi-search-mc.el
+++ b/phi-search-mc.el
@@ -90,7 +90,7 @@
 (require 'multiple-cursors)
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 (defvar phi-search--mc/fake-cursors nil
   "Keeps a list of fake cursors that are activated after exiting phi-search.")
@@ -100,8 +100,8 @@
   (eq (overlay-get ov 'type) 'phi-search--fake-cursor))
 
 (defun phi-search--mc/fake-cursor-at-pos-p (pos)
-  (loop for ov in (overlays-at pos)
-        thereis (phi-search--mc/fake-cursor-p ov)))
+  (cl-loop for ov in (overlays-at pos)
+           thereis (phi-search--mc/fake-cursor-p ov)))
 
 (defun phi-search--mc/add-fake-cursor (pos)
   (or
@@ -130,15 +130,15 @@
 (defun phi-search--mc/activate-fake-cursors ()
   (and phi-search--target
        (phi-search--with-target-buffer
-        (loop for ov in phi-search--mc/fake-cursors do
-              (let ((pos (overlay-start ov)))
-                (delete-overlay ov)
-                (and (/= pos (point))
-                     (loop for o in (overlays-at pos)
-                           never (mc/fake-cursor-p o))
-                     (mc/save-excursion
-                      (goto-char pos)
-                      (mc/create-fake-cursor-at-point)))))
+        (cl-loop for ov in phi-search--mc/fake-cursors do
+                 (let ((pos (overlay-start ov)))
+                   (delete-overlay ov)
+                   (and (/= pos (point))
+                        (cl-loop for o in (overlays-at pos)
+                                 never (mc/fake-cursor-p o))
+                        (mc/save-excursion
+                         (goto-char pos)
+                         (mc/create-fake-cursor-at-point)))))
         (setq phi-search--mc/fake-cursors nil)
         (mc/maybe-multiple-cursors-mode)
         ;; Prevent the fake cursors from moving via mc's post-command-hook

--- a/phi-search-mc.el
+++ b/phi-search-mc.el
@@ -209,9 +209,9 @@ Currently whitespace characters are taken literally, ignoring
 `isearch-lax-whitespace' or `isearch-regexp-lax-whitespace'."
   (interactive)
   (let ((forward isearch-forward)
-        (query (cond ((eq isearch-word 'isearch-symbol-regexp)
+        (query (cond ((eq isearch-regexp-function 'isearch-symbol-regexp)
                       (isearch-symbol-regexp isearch-string))
-                     (isearch-word
+                     (isearch-regexp-function
                       (word-search-regexp isearch-string))
                      (isearch-regexp
                       isearch-string)
@@ -223,7 +223,7 @@ Currently whitespace characters are taken literally, ignoring
       (add-hook 'phi-search-init-hook
                 (lambda ()
                   (insert query)
-                  (and isearch-word
+                  (and isearch-regexp-function
                        (string-match "\\(\\\\_?>\\)\\'" query)
                        (backward-char (length (match-string 1 query))))))
       (if init-func


### PR DESCRIPTION
This fixes some trivial deprecation warnings (`cl` being deprecated, and `isearch-word` obsoleted since 25.1) which appear on (not so) recent versions of emacs.